### PR TITLE
Geteilten Traefik aus der App-Compose entkoppeln

### DIFF
--- a/.github/actions/ensure-proxy/action.yml
+++ b/.github/actions/ensure-proxy/action.yml
@@ -1,0 +1,40 @@
+name: Ensure Shared Proxy
+description: >-
+  Idempotently ensure the shared 'proxy' network and a Traefik reverse proxy
+  exist on the remote Docker host. Safe to call before every app deploy.
+author: odilab
+inputs:
+  ssh_auth_sock:
+    required: true
+    description: "SSH_AUTH_SOCK from the ssh-connect action"
+  docker_host:
+    required: true
+    description: "DOCKER_HOST, e.g. ssh://<alias>"
+runs:
+  using: composite
+  steps:
+    # Composite-Actions erzwingen `required: true` nicht; ungesetzte Inputs
+    # kommen als "" an. DOCKER_HOST="" faellt still auf den lokalen Docker
+    # zurueck — hier benannt fehlschlagen statt auf dem Runner zu deployen.
+    - name: Validate inputs
+      shell: bash
+      env:
+        SSH_AUTH_SOCK: ${{ inputs.ssh_auth_sock }}
+        DOCKER_HOST: ${{ inputs.docker_host }}
+      run: |
+        fail=0
+        [ -n "$DOCKER_HOST" ] || { echo "::error::ensure-proxy: input 'docker_host' is empty"; fail=1; }
+        [ -n "$SSH_AUTH_SOCK" ] || { echo "::error::ensure-proxy: input 'ssh_auth_sock' is empty"; fail=1; }
+        exit "$fail"
+    - name: Ensure shared network and Traefik
+      shell: bash
+      env:
+        SSH_AUTH_SOCK: ${{ inputs.ssh_auth_sock }}
+        DOCKER_HOST: ${{ inputs.docker_host }}
+        COMPOSE_FILE: ${{ github.action_path }}/compose-proxy.yml
+      run: |
+        set -euo pipefail
+        # Externes Netz out-of-band anlegen; kein `down` zerstoert es dann.
+        docker network inspect proxy >/dev/null 2>&1 || docker network create proxy
+        # up -d ist idempotent: laeuft Traefik schon unveraendert, bleibt er stehen.
+        docker compose -f "$COMPOSE_FILE" up -d

--- a/.github/actions/ensure-proxy/compose-proxy.yml
+++ b/.github/actions/ensure-proxy/compose-proxy.yml
@@ -1,0 +1,40 @@
+# Standalone-Traefik: geteilter Ingress fuer den Dev-Host.
+# Projektname `proxy` isoliert ihn von jedem App-Stack.
+# Wird idempotent von der ensure-proxy-Action deployt.
+name: proxy
+
+services:
+  traefik:
+    image: traefik:v3.7.5
+    container_name: traefik
+    restart: always
+    networks:
+      - proxy
+    command:
+      - "--log.level=INFO"
+      - "--accesslog=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      # Default-Netz fuer die Backend-IP-Aufloesung; Apps muessen so das
+      # traefik.docker.network-Label nicht zwingend setzen.
+      - "--providers.docker.network=proxy"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+      - "--certificatesresolvers.erp-service.acme.tlschallenge=true"
+      - "--certificatesresolvers.erp-service.acme.email=hostmaster@optadata-innovationlab.de"
+      - "--certificatesresolvers.erp-service.acme.storage=/letsencrypt/acme.json"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /letsencrypt:/letsencrypt
+
+# Extern: von der ensure-proxy-Action out-of-band angelegt.
+# Kein `down` eines App-Stacks zerstoert es dann.
+networks:
+  proxy:
+    external: true
+    name: proxy

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -50,13 +50,17 @@ jobs:
           port: ${{ env.SSH_PORT }}
           server_ip: ${{ vars.SERVER_IP }}
           ssh_key: ${{ secrets.DEPLOYMENT_KEY }}
+      - name: Ensure shared proxy (Traefik)
+        uses: ./.github/actions/ensure-proxy
+        with:
+          ssh_auth_sock: ${{ steps.ssh-connect.outputs.ssh_auth_sock }}
+          docker_host: ssh://${{ env.SSH_HOST }}
       - name: Deploy IDP-Server
         id: deploy-compose
         env:
           SSH_AUTH_SOCK: ${{ steps.ssh-connect.outputs.ssh_auth_sock }}
           DOCKER_HOST: ssh://${{ env.SSH_HOST }}
           COMPOSE_FILE: docker-compose-dev.yml
-          COMPOSE_PROFILES: dev
           IDP_SERVER_IMAGE: ${{ needs.build.outputs.image }}
           IDP_IDPSIG_FILENAME: file:/credentials/idp_sig.p12
           IDP_IDPENC_FILENAME: file:/credentials/idp_enc.p12
@@ -65,10 +69,10 @@ jobs:
           CREDENTIALS_SOURCE: erp-credentials
           IDP_SERVER_URL: https://dev-idp.optadata-innovationlab.de
         run: |
-          # Kein `down`: mit COMPOSE_PROFILES=dev stoppte es den geteilten Traefik
-          # und griffe das extern referenzierte Netz idp-reference an. `up -d`
-          # legt den idp-server wegen des neuen Image-Tags ohnehin neu an;
-          # --remove-orphans räumt nur Services ab, die nicht mehr hier stehen.
+          # Traefik ist ein eigener Stack (Projekt `proxy`), von hier entkoppelt.
+          # Kein `down`: `up -d` legt den idp-server wegen des neuen Image-Tags
+          # ohnehin neu an; --remove-orphans räumt nur Services ab, die nicht
+          # mehr in dieser App-Compose stehen.
           docker pull ${{ env.IDP_SERVER_IMAGE }}
           docker compose -f ${{ env.COMPOSE_FILE }} up -d --remove-orphans
       # Upstream-Image läuft als uid 10000; die p12s müssen dafür lesbar sein.

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -6,35 +6,9 @@ x-service-setup: &service-setup-ref
 
 x-service-network: &service-network-ref
   networks:
-    idp-reference:
+    proxy:
 
 services:
-  proxy:
-    # Profil dev: nur das Server-Deploy startet diesen Traefik.
-    # Lokal docker-compose-ref.yml nutzen (mappt 8571:8080).
-    profiles:
-      - dev
-    image: traefik:v3.7.5
-    <<: [*service-network-ref, *service-setup-ref]
-    command:
-      - "--log.level=INFO"
-      - "--accesslog=true"
-      - "--providers.docker=true"
-      - "--providers.docker.exposedbydefault=false"
-      - "--entrypoints.web.address=:80"
-      - "--entrypoints.websecure.address=:443"
-      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
-      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
-      - "--certificatesresolvers.erp-service.acme.tlschallenge=true"
-      - "--certificatesresolvers.erp-service.acme.email=hostmaster@optadata-innovationlab.de"
-      - "--certificatesresolvers.erp-service.acme.storage=/letsencrypt/acme.json"
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /letsencrypt:/letsencrypt
-
   idpserver:
     image: ${IDP_SERVER_IMAGE:-ghcr.io/odilab/ref-idp-server:latest}
     user: 10000:10000
@@ -66,7 +40,7 @@ services:
       - ${CREDENTIALS_SOURCE:-../credentials}:/credentials:ro
     labels:
       - "traefik.enable=true"
-      - "traefik.docker.network=idp-reference"
+      - "traefik.docker.network=proxy"
       # Pfad-Allowlist: alles andere beantwortet Traefik mit 404, Spring sieht
       # es nie. Bei neuen Endpunkten erweitern. Bewusst nicht geroutet:
       # /h2-console und Actuator (Port 8180). Kein Host-Port — einziger Ingress.
@@ -88,5 +62,6 @@ volumes:
     external: true
 
 networks:
-  idp-reference:
-    name: idp-reference
+  proxy:
+    external: true
+    name: proxy


### PR DESCRIPTION
## Was

Traefik wird aus `docker-compose-dev.yml` gelöst und als eigener,
idempotent deploybarer Stack betrieben. Der idp-server hängt sich nur
noch ans geteilte externe Netz `proxy`.

## Warum

Traefik lag bisher nur in der idp-Compose, weil idp-server der erste
Dienst im Deploy ist. Das koppelt geteilte Infrastruktur an eine App:
ein `down` hätte den geteilten Traefik gestoppt. Jetzt ist er entkoppelt.

## Änderungen

- Neu: `.github/actions/ensure-proxy/` — Composite-Action plus gebündelte
  `compose-proxy.yml`. Legt das Netz `proxy` an und startet Traefik
  idempotent (Netz anlegen + `docker compose up -d`, kein Health-Gate).
- `docker-compose-dev.yml`: `proxy`-Service entfernt, idpserver ans Netz
  `proxy` gehängt. Routing (Pfad-Allowlist, certresolver, Port 8080)
  unverändert.
- `deploy-dev.yml`: ruft `ensure-proxy` vor dem App-Deploy auf,
  `dev`-Profil entfernt.

## Wichtig vor dem ersten Deploy

Der alte, eingebettete Traefik hält auf dem Host Ports 80/443. Er muss
**einmalig** entfernt werden, sonst scheitert `ensure-proxy` am Port-Bind.

## Scope

Nur ref-idp-server. Die Migration von erp-services auf das geteilte Netz
`proxy` ist ein Folge-Task.