### PR TITLE
ensure-proxy mit odil-actions synchronisieren (ACME per Variable)

### DIFF
--- a/.github/actions/ensure-proxy/action.yml
+++ b/.github/actions/ensure-proxy/action.yml
@@ -10,21 +10,29 @@ inputs:
   docker_host:
     required: true
     description: "DOCKER_HOST, e.g. ssh://<alias>"
+  acme_email:
+    required: true
+    description: "ACME account email for Let's Encrypt (no default; provide via env/secret)"
+  acme_storage:
+    required: false
+    default: "/letsencrypt/acme.json"
+    description: "ACME certificate storage path inside the Traefik container"
 runs:
   using: composite
   steps:
-    # Composite-Actions erzwingen `required: true` nicht; ungesetzte Inputs
-    # kommen als "" an. DOCKER_HOST="" faellt still auf den lokalen Docker
-    # zurueck — hier benannt fehlschlagen statt auf dem Runner zu deployen.
+    # Composite-Actions erzwingen `required` nicht: ein leeres DOCKER_HOST
+    # wuerde still auf den lokalen Docker des Runners statt den Host deployen.
     - name: Validate inputs
       shell: bash
       env:
         SSH_AUTH_SOCK: ${{ inputs.ssh_auth_sock }}
         DOCKER_HOST: ${{ inputs.docker_host }}
+        ACME_EMAIL: ${{ inputs.acme_email }}
       run: |
         fail=0
         [ -n "$DOCKER_HOST" ] || { echo "::error::ensure-proxy: input 'docker_host' is empty"; fail=1; }
         [ -n "$SSH_AUTH_SOCK" ] || { echo "::error::ensure-proxy: input 'ssh_auth_sock' is empty"; fail=1; }
+        [ -n "$ACME_EMAIL" ] || { echo "::error::ensure-proxy: input 'acme_email' is empty"; fail=1; }
         exit "$fail"
     - name: Ensure shared network and Traefik
       shell: bash
@@ -32,9 +40,9 @@ runs:
         SSH_AUTH_SOCK: ${{ inputs.ssh_auth_sock }}
         DOCKER_HOST: ${{ inputs.docker_host }}
         COMPOSE_FILE: ${{ github.action_path }}/compose-proxy.yml
+        TRAEFIK_ACME_EMAIL: ${{ inputs.acme_email }}
+        TRAEFIK_ACME_STORAGE: ${{ inputs.acme_storage }}
       run: |
         set -euo pipefail
-        # Externes Netz out-of-band anlegen; kein `down` zerstoert es dann.
         docker network inspect proxy >/dev/null 2>&1 || docker network create proxy
-        # up -d ist idempotent: laeuft Traefik schon unveraendert, bleibt er stehen.
         docker compose -f "$COMPOSE_FILE" up -d

--- a/.github/actions/ensure-proxy/compose-proxy.yml
+++ b/.github/actions/ensure-proxy/compose-proxy.yml
@@ -1,6 +1,5 @@
 # Standalone-Traefik: geteilter Ingress fuer den Dev-Host.
 # Projektname `proxy` isoliert ihn von jedem App-Stack.
-# Wird idempotent von der ensure-proxy-Action deployt.
 name: proxy
 
 services:
@@ -15,16 +14,15 @@ services:
       - "--accesslog=true"
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
-      # Default-Netz fuer die Backend-IP-Aufloesung; Apps muessen so das
-      # traefik.docker.network-Label nicht zwingend setzen.
+      # Default-Netz, damit Apps kein traefik.docker.network-Label brauchen.
       - "--providers.docker.network=proxy"
       - "--entrypoints.web.address=:80"
       - "--entrypoints.websecure.address=:443"
       - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
       - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
       - "--certificatesresolvers.erp-service.acme.tlschallenge=true"
-      - "--certificatesresolvers.erp-service.acme.email=hostmaster@optadata-innovationlab.de"
-      - "--certificatesresolvers.erp-service.acme.storage=/letsencrypt/acme.json"
+      - "--certificatesresolvers.erp-service.acme.email=${TRAEFIK_ACME_EMAIL}"
+      - "--certificatesresolvers.erp-service.acme.storage=${TRAEFIK_ACME_STORAGE}"
     ports:
       - "80:80"
       - "443:443"
@@ -32,8 +30,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /letsencrypt:/letsencrypt
 
-# Extern: von der ensure-proxy-Action out-of-band angelegt.
-# Kein `down` eines App-Stacks zerstoert es dann.
+# Out-of-band von der Action angelegt; ein App-`down` nimmt es nicht mit.
 networks:
   proxy:
     external: true

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           ssh_auth_sock: ${{ steps.ssh-connect.outputs.ssh_auth_sock }}
           docker_host: ssh://${{ env.SSH_HOST }}
+          acme_email: ${{ vars.ACME_EMAIL }}
       - name: Deploy IDP-Server
         id: deploy-compose
         env:


### PR DESCRIPTION
## Was

Bringt die lokale `ensure-proxy`-Action auf den Stand von `odilab/odil-actions`.
ACME-`email` und -`storage` sind jetzt Action-Inputs. Die E-Mail kommt aus der
Org-Variable `ACME_EMAIL` statt hartkodiert in der Compose.

## Warum

ref-idp-server (public) kann die private `odil-actions` nicht referenzieren und
behält eine lokale Kopie. Beide deployen denselben Traefik (Projekt `proxy`) auf
denselben Dev-Host — driften die Configs, überschreibt der letzte Deploy die des
anderen. Diese Angleichung hält beide Kopien byte-identisch.

## Änderungen

- `action.yml`: neue Inputs `acme_email` (Pflicht) und `acme_storage`
  (Default `/letsencrypt/acme.json`); Validierung von `acme_email`; Übergabe an
  die Compose als `TRAEFIK_ACME_EMAIL` / `TRAEFIK_ACME_STORAGE`.
- `compose-proxy.yml`: `acme.email` und `acme.storage` via `${TRAEFIK_ACME_*}`
  statt hartkodiert.
- `deploy-dev.yml`: `acme_email: ${{ vars.ACME_EMAIL }}` am ensure-proxy-Step.
  `uses:` bleibt lokal (public Repo kann keine private Action referenzieren).

## Hinweise

- `ACME_EMAIL` ist Org-Variable mit Sichtbarkeit `ALL`, im public Repo verfügbar.
- Die zwei Action-Dateien sind byte-identisch mit `odilab/odil-actions`.
- Resolved Traefik-Config bleibt unverändert (gleiche Werte) — `docker compose
  up -d` ist ein No-Op für Traefik, kein Neustart.