### PR TITLE
Versions-Tag aus Jar-Dateiname statt v*-Git-Tags ableiten

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
   workflow_call:
     outputs:
       commit_tag:
@@ -62,13 +60,12 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             TAG_ARGS="${TAG_ARGS} --tag ${IMAGE_REPO}:test"
           fi
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            TAG_ARGS="${TAG_ARGS} --tag ${IMAGE_REPO}:${GITHUB_REF#refs/tags/}"
-          fi
           # main ist protected — ein Push dorthin ist immer ein PR-Merge.
           # Nur dort wird multi-arch gebaut; Dev-Builds bleiben amd64-only.
           if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
             TAG_ARGS="${TAG_ARGS} --tag ${IMAGE_REPO}:latest"
+            VERSION=$(basename idp-server/target/idp-server-*.jar .jar | sed 's/^idp-server-//')
+            TAG_ARGS="${TAG_ARGS} --tag ${IMAGE_REPO}:${VERSION}"
             PLATFORMS="linux/amd64,linux/arm64"
           else
             PLATFORMS="linux/amd64"


### PR DESCRIPTION
## Was

Der Image-Build auf main liest die Projektversion aus dem
Jar-Dateinamen und taggt das Image damit (z.B. `:30.1.0`).
Der tote `v*`-Tag-Trigger entfällt.

## Warum

Die gematik taggt Releases ohne `v`-Prefix (`30.1.0`). "Sync fork"
überträgt keine Tags. Der `v*`-Trigger feuerte deshalb nie.

## Änderungen

- `build-image.yml`: `tags: - 'v*'` Trigger entfernt.
- `build-image.yml`: `v*`-Tag-Bedingung im meta-Step entfernt.
- `build-image.yml`: Bei Push auf main wird die Version aus dem
  Jar-Dateinamen extrahiert und als Image-Tag angehängt.

## Hinweis

Nach dem nächsten "Sync fork" erhält das Image automatisch den
Versions-Tag der gematik-Release (z.B. `:30.1.0`).