### PR TITLE
Upstream-Sync automatisieren, CI-Workflows und Compose aufräumen

### DIFF
--- a/.github/actions/ssh-connect/action.yml
+++ b/.github/actions/ssh-connect/action.yml
@@ -30,8 +30,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
     # Composite-Actions erzwingen `required: true` nicht; ungesetzte
     # Secrets/Variablen kommen als "" an. Hier benannt fehlschlagen.
     - name: Validate inputs

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -54,22 +54,22 @@ jobs:
           COMMIT_TAG=$(git rev-parse --short HEAD)
           IMAGE_REPO="ghcr.io/${{ github.repository }}"
           TAG_ARGS="--tag ${IMAGE_REPO}:${COMMIT_TAG}"
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            TAG_ARGS="${TAG_ARGS} --tag ${IMAGE_REPO}:pr-${{ github.event.pull_request.number }}"
-          fi
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG_ARGS="${TAG_ARGS} --tag ${IMAGE_REPO}:test"
-          fi
+          PLATFORMS="linux/amd64"
           # main ist protected — ein Push dorthin ist immer ein PR-Merge.
           # Nur dort wird multi-arch gebaut; Dev-Builds bleiben amd64-only.
-          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            TAG_ARGS="${TAG_ARGS} --tag ${IMAGE_REPO}:latest"
-            VERSION=$(basename idp-server/target/idp-server-*.jar .jar | sed 's/^idp-server-//')
-            TAG_ARGS="${TAG_ARGS} --tag ${IMAGE_REPO}:${VERSION}"
-            PLATFORMS="linux/amd64,linux/arm64"
-          else
-            PLATFORMS="linux/amd64"
-          fi
+          case "${{ github.event_name }}" in
+            pull_request)
+              TAG_ARGS="${TAG_ARGS} --tag ${IMAGE_REPO}:pr-${{ github.event.pull_request.number }}" ;;
+            workflow_dispatch)
+              TAG_ARGS="${TAG_ARGS} --tag ${IMAGE_REPO}:test" ;;
+            push)
+              if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+                TAG_ARGS="${TAG_ARGS} --tag ${IMAGE_REPO}:latest"
+                VERSION=$(basename idp-server/target/idp-server-*.jar .jar | sed 's/^idp-server-//')
+                TAG_ARGS="${TAG_ARGS} --tag ${IMAGE_REPO}:${VERSION}"
+                PLATFORMS="linux/amd64,linux/arm64"
+              fi ;;
+          esac
           echo "tag=${COMMIT_TAG}" >> $GITHUB_OUTPUT
           echo "image=${IMAGE_REPO}:${COMMIT_TAG}" >> $GITHUB_OUTPUT
           echo "tag_args=${TAG_ARGS}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -82,5 +82,7 @@ jobs:
           --file .github/docker/Dockerfile
           --build-arg COMMIT_HASH=${{ github.sha }}
           --build-arg VERSION=${{ steps.meta.outputs.tag }}
+          --cache-from type=gha
+          --cache-to type=gha,mode=max
           ${{ steps.meta.outputs.tag_args }}
           idp-server/target

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -29,15 +29,15 @@ jobs:
       commit_tag: ${{ steps.meta.outputs.tag }}
       image: ${{ steps.meta.outputs.image }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Login ghcr.io
-        uses: docker/login-action@v4.1.0
+        uses: docker/login-action@v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up JDK
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@v5.7.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -47,7 +47,7 @@ jobs:
       - name: Build Jar
         run: mvn clean package -pl idp-server -am -Dskip.unittests -Dskip.inttests
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Compute tags and platforms
         id: meta
         run: |

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -15,7 +15,6 @@ jobs:
     # Kein secrets:inherit — der Build braucht nur den automatischen GITHUB_TOKEN.
     uses: ./.github/workflows/build-image.yml
   deploy:
-    if: ${{ github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     needs: [ build ]
     # Serialisiert Deploys gegen denselben Host.
     concurrency:
@@ -63,19 +62,12 @@ jobs:
           DOCKER_HOST: ssh://${{ env.SSH_HOST }}
           COMPOSE_FILE: docker-compose-dev.yml
           IDP_SERVER_IMAGE: ${{ needs.build.outputs.image }}
-          IDP_IDPSIG_FILENAME: file:/credentials/idp_sig.p12
-          IDP_IDPENC_FILENAME: file:/credentials/idp_enc.p12
-          IDP_DISCSIG_FILENAME: file:/credentials/disc_sig.p12
+          # Credential-Pfade: Defaults in docker-compose-dev.yml genuegen.
           # Benanntes externes Volume (kein Pfad), geseedet vom Stack odilab/erp-credentials.
           CREDENTIALS_SOURCE: erp-credentials
           IDP_SERVER_URL: https://dev-idp.optadata-innovationlab.de
         run: |
-          # Traefik ist ein eigener Stack (Projekt `proxy`), von hier entkoppelt.
-          # Kein `down`: `up -d` legt den idp-server wegen des neuen Image-Tags
-          # ohnehin neu an; --remove-orphans räumt nur Services ab, die nicht
-          # mehr in dieser App-Compose stehen.
-          docker pull ${{ env.IDP_SERVER_IMAGE }}
-          docker compose -f ${{ env.COMPOSE_FILE }} up -d --remove-orphans
+          docker compose -f ${{ env.COMPOSE_FILE }} up -d --pull always --remove-orphans
       # Upstream-Image läuft als uid 10000; die p12s müssen dafür lesbar sein.
       # Beim Re-Seeden schon einmal gebrochen — lieber hier scheitern als beim p12-Load.
       - name: Verify uid 10000 can read credentials

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -22,7 +22,7 @@ jobs:
       cancel-in-progress: false
     environment:
       name: dev
-      url: https://dev-idp.optadata-innovationlab.de/swagger-ui/index.html
+      url: https://${{ env.DEPLOY_HOSTNAME }}/swagger-ui/index.html
     permissions:
       contents: read
       packages: read
@@ -33,6 +33,7 @@ jobs:
       SSH_HOST: ${{ vars.SSH_HOST }}
       SSH_USER: ${{ vars.SSH_USER }}
       SSH_PORT: ${{ vars.SSH_PORT }}
+      DEPLOY_HOSTNAME: dev-idp.optadata-innovationlab.de
     steps:
       - uses: actions/checkout@v6
       - name: Login ghcr.io
@@ -65,7 +66,7 @@ jobs:
           # Credential-Pfade: Defaults in docker-compose-dev.yml genuegen.
           # Benanntes externes Volume (kein Pfad), geseedet vom Stack odilab/erp-credentials.
           CREDENTIALS_SOURCE: erp-credentials
-          IDP_SERVER_URL: https://dev-idp.optadata-innovationlab.de
+          IDP_SERVER_URL: https://${{ env.DEPLOY_HOSTNAME }}
         run: |
           docker compose -f ${{ env.COMPOSE_FILE }} up -d --pull always --remove-orphans
       # Upstream-Image läuft als uid 10000; die p12s müssen dafür lesbar sein.

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -56,25 +56,21 @@ jobs:
           ssh_auth_sock: ${{ steps.ssh-connect.outputs.ssh_auth_sock }}
           docker_host: ssh://${{ env.SSH_HOST }}
           acme_email: ${{ vars.ACME_EMAIL }}
-      - name: Deploy IDP-Server
+      - name: Deploy and verify IDP-Server
         id: deploy-compose
         env:
           SSH_AUTH_SOCK: ${{ steps.ssh-connect.outputs.ssh_auth_sock }}
           DOCKER_HOST: ssh://${{ env.SSH_HOST }}
           COMPOSE_FILE: docker-compose-dev.yml
           IDP_SERVER_IMAGE: ${{ needs.build.outputs.image }}
-          # Credential-Pfade: Defaults in docker-compose-dev.yml genuegen.
-          # Benanntes externes Volume (kein Pfad), geseedet vom Stack odilab/erp-credentials.
           CREDENTIALS_SOURCE: erp-credentials
           IDP_SERVER_URL: https://${{ env.DEPLOY_HOSTNAME }}
         run: |
-          docker compose -f ${{ env.COMPOSE_FILE }} up -d --pull always --remove-orphans
-      # Upstream-Image läuft als uid 10000; die p12s müssen dafür lesbar sein.
-      # Beim Re-Seeden schon einmal gebrochen — lieber hier scheitern als beim p12-Load.
-      - name: Verify uid 10000 can read credentials
-        env:
-          SSH_AUTH_SOCK: ${{ steps.ssh-connect.outputs.ssh_auth_sock }}
-          DOCKER_HOST: ssh://${{ env.SSH_HOST }}
-        run: |
-          docker run --rm -u 10000:10000 -v erp-credentials:/credentials:ro alpine:3.20 \
-            sh -c 'id -u && cat /credentials/idp_sig.p12 /credentials/idp_enc.p12 /credentials/disc_sig.p12 > /dev/null && echo credentials readable'
+          docker compose -f ${{ env.COMPOSE_FILE }} up -d --pull always --remove-orphans --wait --wait-timeout 120 \
+          || {
+            echo "::error::Container unhealthy after 120s"
+            docker exec idp-server cat /credentials/idp_sig.p12 /credentials/idp_enc.p12 /credentials/disc_sig.p12 > /dev/null \
+              && echo "Credentials readable — startup failure is not credential-related" \
+              || echo "::error::Credentials unreadable for uid 10000"
+            exit 1
+          }

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -35,9 +35,9 @@ jobs:
       SSH_PORT: ${{ vars.SSH_PORT }}
       DEPLOY_HOSTNAME: dev-idp.optadata-innovationlab.de
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Login ghcr.io
-        uses: docker/login-action@v4.1.0
+        uses: docker/login-action@v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,46 @@
+name: Sync upstream (gematik)
+on:
+  schedule:
+    # Montags 06:00 UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Sync fork master
+        id: sync
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          MERGE_TYPE=$(gh api repos/${{ github.repository }}/merge-upstream \
+            -f branch=master --jq '.merge_type' 2>/dev/null) || true
+          echo "merge_type=${MERGE_TYPE:-none}" >> $GITHUB_OUTPUT
+          echo "merge-upstream: ${MERGE_TYPE:-none}"
+
+      - name: Create sync PR
+        if: steps.sync.outputs.merge_type != 'none'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh pr list --repo ${{ github.repository }} \
+            --base main --head master --state open \
+            --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            echo "Offene Sync-PR #${EXISTING} existiert"
+            exit 0
+          fi
+          SUBJECT=$(gh api repos/${{ github.repository }}/branches/master \
+            --jq '.commit.commit.message' | head -1)
+          PR_URL=$(gh pr create \
+            --repo ${{ github.repository }} \
+            --base main \
+            --head master \
+            --title "Upstream-Sync: ${SUBJECT}" \
+            --body "Automatischer Sync von gematik/ref-idp-server master.")
+          echo "PR erstellt: ${PR_URL}"
+          gh pr merge --auto --merge "${PR_URL}"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,20 +1,13 @@
-x-environment-timezone: &environment-timezone-ref
-  TZ: Europe/Berlin
-
-x-service-setup: &service-setup-ref
-  restart: always
-
-x-service-network: &service-network-ref
-  networks:
-    proxy:
-
 services:
   idpserver:
     image: ${IDP_SERVER_IMAGE:-ghcr.io/odilab/ref-idp-server:latest}
     user: 10000:10000
     container_name: idp-server
-    <<: [*service-network-ref, *service-setup-ref]
+    restart: always
+    networks:
+      proxy:
     environment:
+      TZ: Europe/Berlin
       # Default: OrbStack-Hostname für lokale Läufe; das Deploy setzt die
       # öffentliche URL. Der Wert landet 1:1 im Discovery-Dokument.
       IDP_SERVER_URL: "${IDP_SERVER_URL:-https://idp-server.ref-idp-server.orb.local}"
@@ -29,11 +22,10 @@ services:
       # https statt des http-Defaults der application.yml; muss exakt dem
       # redirect_uri der App entsprechen, sonst 1020 an /sign_response.
       IDP_REGISTEREDCLIENT_EREZEPTAPP_REDIRECTURI: "https://redirect.gematik.de/erezept"
-      MANAGEMENT_PORT: 8180 # Spring Actuator Port
+      MANAGEMENT_PORT: 8180
       # Defense-in-depth: application.yml aktiviert die H2-Console samt
       # web-allow-others — sie antwortete sonst jedem Container im Netz.
       SPRING_H2_CONSOLE_ENABLED: "false"
-      <<: *environment-timezone-ref
     # Deploy: benanntes externes Volume erp-credentials. Lokal: Bind-Pfad —
     # relative Pfade löst der Compose-Client auf, nicht der remote Docker-Host.
     volumes:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -37,7 +37,7 @@ services:
       # es nie. Bei neuen Endpunkten erweitern. Bewusst nicht geroutet:
       # /h2-console und Actuator (Port 8180). Kein Host-Port — einziger Ingress.
       - >-
-        traefik.http.routers.idp-server.rule=Host(`dev-idp.optadata-innovationlab.de`) &&
+        traefik.http.routers.idp-server.rule=Host(`${DEPLOY_HOSTNAME:-dev-idp.optadata-innovationlab.de}`) &&
         (Path(`/.well-known/openid-configuration`) || Path(`/discoveryDocument`) ||
         Path(`/auth/realms/idp/.well-known/openid-configuration`) || Path(`/jwks`) ||
         Path(`/idpSig/jwk.json`) || Path(`/idpEnc/jwk.json`) ||


### PR DESCRIPTION
## Was

Wöchentlicher Workflow synct gematik/master automatisch
nach odilab/main. Dazu CI-Workflows und Compose aufgeräumt:
Layer-Cache, Healthcheck-Deploy, Hostname-Parametrierung.

## Warum

Upstream-Änderungen mussten bisher manuell gesynct werden.
Builds liefen ohne Layer-Cache. Nach dem Deploy fehlte die
Prüfung, ob der Container startet.

## Änderungen

- `sync-upstream.yml` (neu): `merge-upstream`-API synct
  gematik/master → odilab/master. Erstellt PR master → main
  mit Auto-Merge. Wöchentlich (Mo 06:00 UTC) und manuell.
- `build-image.yml`: buildx GHA-Cache aktiviert,
  Tag-Logik auf `case`-Anweisung umgestellt.
- `deploy-dev.yml`: Deploy wartet auf Healthcheck
  (`--wait --wait-timeout 120`). Bei Fehler prüft
  `docker exec` die Credentials. Separater Alpine-Container
  und redundante Env-Vars entfallen.
- `docker-compose-dev.yml`: Hostname über `${DEPLOY_HOSTNAME}`
  parametriert, Anchors inline aufgelöst.
- `ssh-connect/action.yml`: Redundanten Checkout entfernt.

## Hinweis

Der Sync-Workflow setzt "Allow auto-merge" voraus (aktiviert).
Der erste Build nach dem Merge füllt den GHA-Cache.